### PR TITLE
Add warning about new workers not sharing a global state

### DIFF
--- a/src/managers.jl
+++ b/src/managers.jl
@@ -450,6 +450,11 @@ Launch `np` workers on the local host using the in-built `LocalManager`.
 Local workers inherit the current package environment (i.e., active project,
 [`LOAD_PATH`](@ref), and [`DEPOT_PATH`](@ref)) from the main process.
 
+!!! warning
+    Note that workers do not run a `~/.julia/config/startup.jl` startup script, nor do they synchronize
+    their global state (such as command-line switches, global variables, new method definitions, and loaded modules) with any
+    of the other running processes.
+
 **Keyword arguments**:
  - `restrict::Bool`: if `true` (default) binding is restricted to `127.0.0.1`.
  - `dir`, `exename`, `exeflags`, `env`, `topology`, `lazy`, `enable_threaded_blas`: same effect


### PR DESCRIPTION
Originally proposed in https://github.com/JuliaLang/julia/pull/50843