### PR TITLE
Guard rmprocs in tests to avoid warning. Fix leaky stderr from SIGTERM test.

### DIFF
--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1920,6 +1920,8 @@ begin
         remote_do(w) do
             # Cause the 'exit()' message that `rmprocs()` sends to do nothing
             Core.eval(Base, :(exit() = nothing))
+            # Hide the trace that `rmprocs()` will cause this worker to show
+            redirect_stderr(devnull)
         end
         wait(rmprocs([w]))
     end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1906,7 +1906,7 @@ end end
 include("splitrange.jl")
 
 # Clear all workers for timeout tests (issue #45785)
-rmprocs(workers())
+nprocs() > 1 && rmprocs(workers())
 begin
     # First, assert that we get no messages when we close a cooperative worker
     w = only(addprocs(1))
@@ -1927,5 +1927,5 @@ end
 
 # Run topology tests last after removing all workers, since a given
 # cluster at any time only supports a single topology.
-rmprocs(workers())
+nprocs() > 1 && rmprocs(workers())
 include("topology.jl")

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -134,7 +134,7 @@ for (i, (from,to)) in enumerate(combinations)
 end
 
 # With lazy=false, all connections ought to be setup during `addprocs`
-rmprocs(workers())
+nprocs() > 1 && rmprocs(workers())
 addprocs_with_testenv(8; lazy=false)
 def_count_conn()
 @test sum(asyncmap(p->remotecall_fetch(count_connected_workers,p), workers())) == 64


### PR DESCRIPTION
Fixes 
```
  | ┌ Warning: rmprocs: process 1 not removed
  | └ @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-XC9YQX9HH2.0/build/default-honeycrisp-XC9YQX9HH2-0/julialang/julia-master/julia-83f908a311/share/julia/stdlib/v1.12/Distributed/src/cluster.jl:1049
```

Fixes https://github.com/JuliaLang/Distributed.jl/issues/15