### PR TITLE
Don't rely on implicit binding creation by setglobal

### DIFF
--- a/src/clusterserialize.jl
+++ b/src/clusterserialize.jl
@@ -167,10 +167,11 @@ function deserialize_global_from_main(s::ClusterSerializer, sym)
             return nothing
         end
     end
+    Core.eval(Main, Expr(:global, sym))
     if sym_isconst
         ccall(:jl_set_const, Cvoid, (Any, Any, Any), Main, sym, v)
     else
-        setglobal!(Main, sym, v)
+        invokelatest(setglobal!, Main, sym, v)
     end
     return nothing
 end


### PR DESCRIPTION
As discussed in [1], the implicit creation of bindings through the setglobal! intrinsic was accidentally added in 1.9 unintentionally and will be removed (ideally) or at the very least deprecated in 1.11.

The recommended replacement syntax is `Core.eval(mod, Expr(:global, sym))` to introduce the binding and `invokelatest(setglobal!, mod, sym, val)` to set it. The invokelatest is not presently required, but may be required for https://github.com/JuliaLang/julia/pull/54654, so it's included in the recommendation.

[1] https://github.com/JuliaLang/julia/issues/54607