### PR TITLE
Use `SIGQUIT` instead of `SIGTERM`

### DIFF
--- a/src/managers.jl
+++ b/src/managers.jl
@@ -747,12 +747,12 @@ function kill(manager::LocalManager, pid::Int, config::WorkerConfig; exit_timeou
 
         # Check to see if our child exited, and if not, send an actual kill signal
         if !process_exited(config.process)
-            @warn("Failed to gracefully kill worker $(pid), sending SIGTERM")
-            kill(config.process, Base.SIGTERM)
+            @warn("Failed to gracefully kill worker $(pid), sending SIGQUIT")
+            kill(config.process, Base.SIGQUIT)
 
             sleep(term_timeout)
             if !process_exited(config.process)
-                @warn("Worker $(pid) ignored SIGTERM, sending SIGKILL")
+                @warn("Worker $(pid) ignored SIGQUIT, sending SIGKILL")
                 kill(config.process, Base.SIGKILL)
             end
         end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1916,7 +1916,7 @@ begin
 
     # Next, ensure we get a log message when a worker does not cleanly exit
     w = only(addprocs(1))
-    @test_logs (:warn, r"sending SIGTERM") begin
+    @test_logs (:warn, r"sending SIGQUIT") begin
         remote_do(w) do
             # Cause the 'exit()' message that `rmprocs()` sends to do nothing
             Core.eval(Base, :(exit() = nothing))


### PR DESCRIPTION
This allows for easier collection of core dumps.
X-ref: https://github.com/JuliaLang/julia/pull/45864