### PR TITLE
Implement Base.isempty(::RemoteChannel)

### DIFF
--- a/src/remotecall.jl
+++ b/src/remotecall.jl
@@ -768,6 +768,9 @@ close(rr::RemoteChannel) = call_on_owner(close_ref, rr)
 isopen_ref(rid) = isopen(lookup_ref(rid).c)
 isopen(rr::RemoteChannel) = call_on_owner(isopen_ref, rr)
 
+isempty_ref(rid) = isempty(lookup_ref(rid).c)
+Base.isempty(rr::RemoteChannel) = call_on_owner(isempty_ref, rr)
+
 getindex(r::RemoteChannel) = fetch(r)
 getindex(r::Future) = fetch(r)
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -497,6 +497,18 @@ let ch = RemoteChannel(() -> Channel(1))
     @test 10 == test_iteration_collect(ch)
 end
 
+# Test isempty(::RemoteChannel). This should not modify the underlying
+# AbstractChannel, which Base's default implementation will do.
+let
+    chan = Channel(1)
+    push!(chan, 1)
+    remotechan = RemoteChannel(() -> chan)
+
+    @test !isempty(remotechan)
+    # Calling `isempty(remotechan)` shouldn't have modified `chan`
+    @test !isempty(chan)
+end
+
 # make sure exceptions propagate when waiting on Tasks
 @test_throws CompositeException (@sync (@async error("oops")))
 try


### PR DESCRIPTION
The default method from Base has the nasty side-effect of take!()'ing from the underlying channel.