### PR TITLE
Adding better docs to exeflags kwarg

### DIFF
--- a/src/managers.jl
+++ b/src/managers.jl
@@ -111,7 +111,9 @@ addprocs([
   version is used on all remote machines because serialization and code distribution might
   fail otherwise.
 
-* `exeflags`: additional flags passed to the worker processes.
+* `exeflags`: additional flags passed to the worker processes. It can either be a `Cmd`, a `String`
+  holding one flag, or a collection of strings, with one element per flag.
+  E.g. `\`--threads=auto project=.\``, `"--compile-trace=stderr"` or `["--threads=auto", "--compile=all"]`. 
 
 * `topology`: Specifies how the workers connect to each other. Sending a message between
   unconnected workers results in an error.


### PR DESCRIPTION
Should close https://github.com/JuliaLang/julia/issues/45172

The `exeflags` kwarg is very confusing and can lead to unexpected behavior when passing multiple flags in a single string, a first step is to get better docs on it.