### PR TITLE
Fix docstring of `@everywhere`

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -185,9 +185,9 @@ processes to have execute the expression.
 
 Similar to calling `remotecall_eval(Main, procs, expr)`, but with two extra features:
 
-    - `using` and `import` statements run on the calling process first, to ensure
-      packages are precompiled.
-    - The current source file path used by `include` is propagated to other processes.
+- `using` and `import` statements run on the calling process first, to ensure
+  packages are precompiled.
+- The current source file path used by `include` is propagated to other processes.
 """
 macro everywhere(ex)
     procs = GlobalRef(@__MODULE__, :procs)


### PR DESCRIPTION
The random extra spaces screw up formatting: https://docs.julialang.org/en/v1.10.5/stdlib/Distributed/#Distributed.@everywhere