### PR TITLE
Reformat README and update development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,43 @@
 # Distributed
 
-The `Distributed` package provides functionality for creating and controlling multiple Julia processes remotely, and for performing distributed and parallel computing. It uses network sockets or other supported interfaces to communicate between Julia processes, and relies on Julia's `Serialization` stdlib package to transform Julia objects into a format that can be transferred between processes efficiently. It provides a full set of utilities to create and destroy new Julia processes and add them to a "cluster" (a collection of Julia processes connected together), as well as functions to perform Remote Procedure Calls (RPC) between the processes within a cluster. See the `API` section for details.
+The `Distributed` package provides functionality for creating and controlling
+multiple Julia processes remotely, and for performing distributed and parallel
+computing. It uses network sockets or other supported interfaces to communicate
+between Julia processes, and relies on Julia's `Serialization` stdlib package to
+transform Julia objects into a format that can be transferred between processes
+efficiently. It provides a full set of utilities to create and destroy new Julia
+processes and add them to a "cluster" (a collection of Julia processes connected
+together), as well as functions to perform Remote Procedure Calls (RPC) between
+the processes within a cluster. See the `API` section for details.
 
 This package ships as part of the Julia stdlib.
 
 ## Using development versions of this package
 
-To use a newer version of this package, you need to build Julia from scratch. The build process is the same as any other build except that you need to change the commit used in `stdlib/Distributed.version`.
+### On Julia 1.11+
+In Julia 1.11 Distributed was excised from the default system image and became
+more of an independent package. As such, to use a different version it's enough
+to just `dev` it explicitly:
+```julia-repl
+pkg> dev https://github.com/JuliaLang/Distributed.jl.git
+```
 
-It's also possible to load a development version of the package using [the trick used in the Section named "Using the development version of Pkg.jl" in the `Pkg.jl` repo](https://github.com/JuliaLang/Pkg.jl#using-the-development-version-of-pkgjl), but the capabilities are limited as all other packages will depend on the stdlib version of the package and will not work with the modified package.
+### On older Julia versions
+To use a newer version of this package on older Julia versions, you need to build
+Julia from scratch. The build process is the same as any other build except that
+you need to change the commit used in `stdlib/Distributed.version`.
+
+It's also possible to load a development version of the package using [the trick
+used in the Section named "Using the development version of Pkg.jl" in the
+`Pkg.jl`
+repo](https://github.com/JuliaLang/Pkg.jl#using-the-development-version-of-pkgjl),
+but the capabilities are limited as all other packages will depend on the stdlib
+version of the package and will not work with the modified package.
 
 ## API
 
-The public API of `Distributed` consists of a variety of functions for various tasks; for creating and destroying processes within a cluster:
+The public API of `Distributed` consists of a variety of functions for various
+tasks; for creating and destroying processes within a cluster:
 
 - `addprocs` - create one or more Julia processes and connect them to the cluster
 - `rmprocs` - shutdown and remove one or more Julia processes from the cluster
@@ -20,7 +45,9 @@ The public API of `Distributed` consists of a variety of functions for various t
 For controlling other processes via RPC:
 
 - `remotecall` - call a function on another process and return a `Future` referencing the result of that call
-- `Future` - an object that references the result of a `remotecall` that hasn't yet completed - use `fetch` to return the call's result, or `wait` to just wait for the remote call to finish
+- `Future` - an object that references the result of a `remotecall` that hasn't
+  yet completed - use `fetch` to return the call's result, or `wait` to just
+  wait for the remote call to finish.
 - `remotecall_fetch` - the same as `fetch(remotecall(...))`
 - `remotecall_wait` - the same as `wait(remotecall(...))`
 - `remote_do` - like `remotecall`, but does not provide a way to access the result of the call
@@ -49,6 +76,15 @@ For controlling multiple processes at once:
 
 ### Process Identifiers
 
-Julia processes connected with `Distributed` are all assigned a cluster-unique `Int` identifier, starting from `1`. The first Julia process within a cluster is given ID `1`, while other processes added via `addprocs` get incrementing IDs (`2`, `3`, etc.). Functions and macros which communicate from one process to another usually take one or more identifiers to determine which process they target - for example, `remotecall_fetch(myid, 2)` calls `myid()` on process 2.
+Julia processes connected with `Distributed` are all assigned a cluster-unique
+`Int` identifier, starting from `1`. The first Julia process within a cluster is
+given ID `1`, while other processes added via `addprocs` get incrementing IDs
+(`2`, `3`, etc.). Functions and macros which communicate from one process to
+another usually take one or more identifiers to determine which process they
+target - for example, `remotecall_fetch(myid, 2)` calls `myid()` on process 2.
 
-**Note:** Only process 1 (often called the "head", "primary", or "master") may add or remove processes, and manages the rest of the cluster. Other processes (called "workers" or "worker processes") may still call functions on each other and send and receive data, but `addprocs`/`rmprocs` on worker processes will fail with an error.
+**Note:** Only process 1 (often called the "head", "primary", or "master") may
+add or remove processes, and manages the rest of the cluster. Other processes
+(called "workers" or "worker processes") may still call functions on each other
+and send and receive data, but `addprocs`/`rmprocs` on worker processes will
+fail with an error.


### PR DESCRIPTION
All content is the same, except for the new section about how to use development versions on Julia 1.11+.

Fixes #113.