### PR TITLE
Thread-safety improvements. Add tests with multiple threads. CI improvements.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64
           - x86
-        exclude:
+        include:
           - os: macOS-latest
-            arch: x86
+            arch: aarch64
+            version: 'nightly'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,24 +17,27 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: julia -t${{ matrix.threads}} - ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - 'nightly'
-        os:
-          - ubuntu-latest
-          - windows-latest
-        arch:
-          - x64
-          - x86
-        include:
-          - os: macOS-latest
+        threads:
+          # - '1'
+          - '4,4'
+        version: [nightly]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        arch: [x64, x86, aarch64]
+        exclude:
+          - os: ubuntu-latest
             arch: aarch64
-            version: 'nightly'
+          - os: windows-latest
+            arch: aarch64
+          - os: macOS-latest
+            arch: x64
+          - os: macOS-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -45,7 +48,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_DISTRIBUTED_TESTING_STANDALONE: 1
-          JULIA_NUM_THREADS: 4,4
+          JULIA_NUM_THREADS: '${{ matrix.threads}}'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_DISTRIBUTED_TESTING_STANDALONE: 1
+          JULIA_NUM_THREADS: 4,4
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -230,7 +230,7 @@ function remotecall_eval(m::Module, procs, ex)
         # execute locally last as we do not want local execution to block serialization
         # of the request to remote nodes.
         for _ in 1:run_locally
-            Threads.@spawn Threads.threadpool() Core.eval(m, ex)
+            @async Core.eval(m, ex)
         end
     end
     nothing
@@ -275,7 +275,7 @@ function preduce(reducer, f, R)
 end
 
 function pfor(f, R)
-    t = Threads.@spawn Threads.threadpool() @sync for c in splitrange(Int(firstindex(R)), Int(lastindex(R)), nworkers())
+    t = @async @sync for c in splitrange(Int(firstindex(R)), Int(lastindex(R)), nworkers())
         @spawnat :any f(R, first(c), last(c))
     end
     errormonitor(t)

--- a/src/managers.jl
+++ b/src/managers.jl
@@ -113,7 +113,7 @@ addprocs([
 
 * `exeflags`: additional flags passed to the worker processes. It can either be a `Cmd`, a `String`
   holding one flag, or a collection of strings, with one element per flag.
-  E.g. `\`--threads=auto project=.\``, `"--compile-trace=stderr"` or `["--threads=auto", "--compile=all"]`. 
+  E.g. `\`--threads=auto project=.\``, `"--compile-trace=stderr"` or `["--threads=auto", "--compile=all"]`.
 
 * `topology`: Specifies how the workers connect to each other. Sending a message between
   unconnected workers results in an error.
@@ -740,7 +740,8 @@ function kill(manager::SSHManager, pid::Int, config::WorkerConfig)
     nothing
 end
 
-function kill(manager::LocalManager, pid::Int, config::WorkerConfig; exit_timeout = 15, term_timeout = 15)
+function kill(manager::LocalManager, pid::Int, config::WorkerConfig; profile_wait = 6, exit_timeout = 15, term_timeout = 15)
+    # profile_wait = 6 is 1s for profile, 5s for the report to show
     # First, try sending `exit()` to the remote over the usual control channels
     remote_do(exit, pid)
 
@@ -749,7 +750,14 @@ function kill(manager::LocalManager, pid::Int, config::WorkerConfig; exit_timeou
 
         # Check to see if our child exited, and if not, send an actual kill signal
         if !process_exited(config.process)
-            @warn("Failed to gracefully kill worker $(pid), sending SIGQUIT")
+            @warn "Failed to gracefully kill worker $(pid)"
+            profile_sig = Sys.iswindows() ? nothing : Sys.isbsd() ? ("SIGINFO", 29) : ("SIGUSR1" , 10)
+            if profile_sig !== nothing
+                @warn("Sending profile $(profile_sig[1]) to worker $(pid)")
+                kill(config.process, profile_sig[2])
+                sleep(profile_wait)
+            end
+            @warn("Sending SIGQUIT to worker $(pid)")
             kill(config.process, Base.SIGQUIT)
 
             sleep(term_timeout)

--- a/src/managers.jl
+++ b/src/managers.jl
@@ -178,7 +178,7 @@ function launch(manager::SSHManager, params::Dict, launched::Array, launch_ntfy:
     # Wait for all launches to complete.
     @sync for (i, (machine, cnt)) in enumerate(manager.machines)
         let machine=machine, cnt=cnt
-            Threads.@spawn Threads.threadpool() try
+            @async try
                 launch_on_machine(manager, $machine, $cnt, params, launched, launch_ntfy)
             catch e
                 print(stderr, "exception launching on machine $(machine) : $(e)\n")
@@ -744,7 +744,7 @@ function kill(manager::LocalManager, pid::Int, config::WorkerConfig; exit_timeou
     # First, try sending `exit()` to the remote over the usual control channels
     remote_do(exit, pid)
 
-    timer_task = Threads.@spawn Threads.threadpool() begin
+    timer_task = @async begin
         sleep(exit_timeout)
 
         # Check to see if our child exited, and if not, send an actual kill signal

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -194,7 +194,7 @@ end
 function flush_gc_msgs()
     try
         for w in (PGRP::ProcessGroup).workers
-            if isa(w,Worker) && (w.state == W_CONNECTED) && w.gcflag
+            if isa(w,Worker) && ((@atomic w.state) == W_CONNECTED) && w.gcflag
                 flush_gc_msgs(w)
             end
         end

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -200,7 +200,7 @@ function flush_gc_msgs()
         end
     catch e
         bt = catch_backtrace()
-        Threads.@spawn showerror(stderr, e, bt)
+        @async showerror(stderr, e, bt)
     end
 end
 

--- a/src/process_messages.jl
+++ b/src/process_messages.jl
@@ -85,7 +85,7 @@ function schedule_call(rid, thunk)
         rv = RemoteValue(def_rv_channel())
         (PGRP::ProcessGroup).refs[rid] = rv
         push!(rv.clientset, rid.whence)
-        errormonitor(Threads.@spawn run_work_thunk(rv, thunk))
+        errormonitor(@async run_work_thunk(rv, thunk))
         return rv
     end
 end
@@ -118,7 +118,7 @@ end
 
 ## message event handlers ##
 function process_messages(r_stream::TCPSocket, w_stream::TCPSocket, incoming::Bool=true)
-    errormonitor(Threads.@spawn process_tcp_streams(r_stream, w_stream, incoming))
+    errormonitor(@async process_tcp_streams(r_stream, w_stream, incoming))
 end
 
 function process_tcp_streams(r_stream::TCPSocket, w_stream::TCPSocket, incoming::Bool)
@@ -148,7 +148,7 @@ Julia version number to perform the authentication handshake.
 See also [`cluster_cookie`](@ref).
 """
 function process_messages(r_stream::IO, w_stream::IO, incoming::Bool=true)
-    errormonitor(Threads.@spawn message_handler_loop(r_stream, w_stream, incoming))
+    errormonitor(@async message_handler_loop(r_stream, w_stream, incoming))
 end
 
 function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
@@ -283,7 +283,7 @@ function handle_msg(msg::CallMsg{:call}, header, r_stream, w_stream, version)
     schedule_call(header.response_oid, ()->invokelatest(msg.f, msg.args...; msg.kwargs...))
 end
 function handle_msg(msg::CallMsg{:call_fetch}, header, r_stream, w_stream, version)
-    errormonitor(Threads.@spawn begin
+    errormonitor(@async begin
         v = run_work_thunk(()->invokelatest(msg.f, msg.args...; msg.kwargs...), false)
         if isa(v, SyncTake)
             try
@@ -299,7 +299,7 @@ function handle_msg(msg::CallMsg{:call_fetch}, header, r_stream, w_stream, versi
 end
 
 function handle_msg(msg::CallWaitMsg, header, r_stream, w_stream, version)
-    errormonitor(Threads.@spawn begin
+    errormonitor(@async begin
         rv = schedule_call(header.response_oid, ()->invokelatest(msg.f, msg.args...; msg.kwargs...))
         deliver_result(w_stream, :call_wait, header.notify_oid, fetch(rv.c))
         nothing
@@ -307,7 +307,7 @@ function handle_msg(msg::CallWaitMsg, header, r_stream, w_stream, version)
 end
 
 function handle_msg(msg::RemoteDoMsg, header, r_stream, w_stream, version)
-    errormonitor(Threads.@spawn run_work_thunk(()->invokelatest(msg.f, msg.args...; msg.kwargs...), true))
+    errormonitor(@async run_work_thunk(()->invokelatest(msg.f, msg.args...; msg.kwargs...), true))
 end
 
 function handle_msg(msg::ResultMsg, header, r_stream, w_stream, version)
@@ -350,7 +350,7 @@ function handle_msg(msg::JoinPGRPMsg, header, r_stream, w_stream, version)
                 # The constructor registers the object with a global registry.
                 Worker(rpid, ()->connect_to_peer(cluster_manager, rpid, wconfig))
             else
-                Threads.@spawn connect_to_peer(cluster_manager, rpid, wconfig)
+                @async connect_to_peer(cluster_manager, rpid, wconfig)
             end
         end
     end

--- a/src/process_messages.jl
+++ b/src/process_messages.jl
@@ -222,7 +222,7 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
             println(stderr, "Process($(myid())) - Unknown remote, closing connection.")
         elseif !(wpid in map_del_wrkr)
             werr = worker_from_id(wpid)
-            oldstate = werr.state
+            oldstate = @atomic werr.state
             set_worker_state(werr, W_TERMINATED)
 
             # If unhandleable error occurred talking to pid 1, exit

--- a/src/remotecall.jl
+++ b/src/remotecall.jl
@@ -205,7 +205,7 @@ or to use a local [`Channel`](@ref) as a proxy:
 ```julia
 p = 1
 f = Future(p)
-errormonitor(Threads.@spawn put!(f, remotecall_fetch(long_computation, p)))
+errormonitor(@async put!(f, remotecall_fetch(long_computation, p)))
 isready(f)  # will not block
 ```
 """
@@ -274,7 +274,7 @@ end
 const any_gc_flag = Threads.Condition()
 function start_gc_msgs_task()
     errormonitor(
-        Threads.@spawn begin
+        @async begin
             while true
                 lock(any_gc_flag) do
                     # this might miss events
@@ -322,7 +322,7 @@ function process_worker(rr)
     msg = (remoteref_id(rr), myid())
 
     # Needs to acquire a lock on the del_msg queue
-    T = Threads.@spawn Threads.threadpool() begin
+    T = @async begin
         publish_del_msg!($w, $msg)
     end
     Base.errormonitor(T)

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1734,18 +1734,17 @@ function reuseport_tests()
     end
 
     # Ensure that the code has indeed been successfully executed everywhere
-    @test all(in(results), procs())
+    return all(in(results), procs())
 end
 
 # Test that the client port is reused. SO_REUSEPORT may not be supported on
 # all UNIX platforms, Linux kernels prior to 3.9 and older versions of OSX
 @assert nprocs() == 1
 addprocs_with_testenv(4; lazy=false)
-if ccall(:jl_has_so_reuseport, Int32, ()) == 1
-    reuseport_tests()
-else
-    @info "SO_REUSEPORT is unsupported, skipping reuseport tests"
-end
+
+skip_reuseexport = ccall(:jl_has_so_reuseport, Int32, ()) != 1
+skip_reuseexport && @debug "SO_REUSEPORT support missing, reuseport_tests skipped"
+@test reuseport_tests() skip = skip_reuseexport
 
 # issue #27933
 a27933 = :_not_defined_27933

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1937,7 +1937,7 @@ begin
 
     # Next, ensure we get a log message when a worker does not cleanly exit
     w = only(addprocs(1))
-    @test_logs (:warn, r"sending SIGQUIT") begin
+    @test_logs (:warn, r"Sending SIGQUIT") match_mode=:any begin
         remote_do(w) do
             # Cause the 'exit()' message that `rmprocs()` sends to do nothing
             Core.eval(Base, :(exit() = nothing))

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1850,7 +1850,7 @@ let julia = `$(Base.julia_cmd()) --startup-file=no`; mktempdir() do tmp
     end
     """
     cmd = setenv(`$(julia) -p1 -e $(testcode * extracode)`, env)
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
     # --project
     extracode = """
     for w in workers()
@@ -1859,11 +1859,11 @@ let julia = `$(Base.julia_cmd()) --startup-file=no`; mktempdir() do tmp
     end
     """
     cmd = setenv(`$(julia) --project=$(project) -p1 -e $(testcode * extracode)`, env)
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
     # JULIA_PROJECT
     cmd = setenv(`$(julia) -p1 -e $(testcode * extracode)`,
                  (env["JULIA_PROJECT"] = project; env))
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
     # Pkg.activate(...)
     activateish = """
     Base.ACTIVE_PROJECT[] = $(repr(project))
@@ -1871,7 +1871,7 @@ let julia = `$(Base.julia_cmd()) --startup-file=no`; mktempdir() do tmp
     addprocs(1)
     """
     cmd = setenv(`$(julia) -e $(activateish * testcode * extracode)`, env)
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
     # JULIA_(LOAD|DEPOT)_PATH
     shufflecode = """
     d = reverse(DEPOT_PATH)
@@ -1890,7 +1890,7 @@ let julia = `$(Base.julia_cmd()) --startup-file=no`; mktempdir() do tmp
     end
     """
     cmd = setenv(`$(julia) -e $(shufflecode * addcode * testcode * extracode)`, env)
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
     # Mismatch when shuffling after proc addition
     failcode = shufflecode * setupcode * """
     for w in workers()
@@ -1899,7 +1899,7 @@ let julia = `$(Base.julia_cmd()) --startup-file=no`; mktempdir() do tmp
     end
     """
     cmd = setenv(`$(julia) -p1 -e $(failcode)`, env)
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
     # Passing env or exeflags to addprocs(...) to override defaults
     envcode = """
     using Distributed
@@ -1921,7 +1921,7 @@ let julia = `$(Base.julia_cmd()) --startup-file=no`; mktempdir() do tmp
     end
     """
     cmd = setenv(`$(julia) -e $(envcode)`, env)
-    @test success(cmd)
+    @test success(pipeline(cmd; stdout, stderr))
 end end
 
 include("splitrange.jl")

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -151,27 +151,6 @@ function poll_while(f::Function; timeout_seconds::Integer = 120)
     return true
 end
 
-function _getenv_include_thread_unsafe()
-    environment_variable_name = "JULIA_TEST_INCLUDE_THREAD_UNSAFE"
-    default_value = "false"
-    environment_variable_value = strip(get(ENV, environment_variable_name, default_value))
-    b = parse(Bool, environment_variable_value)::Bool
-    return b
-end
-const _env_include_thread_unsafe = _getenv_include_thread_unsafe()
-function include_thread_unsafe_tests()
-    if Threads.maxthreadid() > 1
-        if _env_include_thread_unsafe
-            return true
-        end
-        msg = "Skipping a thread-unsafe test because `Threads.maxthreadid() > 1`"
-        @warn msg Threads.maxthreadid()
-        Test.@test_broken false
-        return false
-    end
-    return true
-end
-
 # Distributed GC tests for Futures
 function test_futures_dgc(id)
     f = remotecall(myid, id)
@@ -294,16 +273,16 @@ let wid1 = workers()[1],
     fstore = RemoteChannel(wid2)
 
     put!(fstore, rr)
-    if include_thread_unsafe_tests()
-        # timedwait() is necessary because wid1 is asynchronously informed of
-        # the existence of rr/rrid through the call to `put!(fstore, rr)`.
-        @test timedwait(() -> remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid), 10) === :ok
-    end
+
+    # timedwait() is necessary because wid1 is asynchronously informed of
+    # the existence of rr/rrid through the call to `put!(fstore, rr)`.
+    @test timedwait(() -> remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid), 10) === :ok
+
     finalize(rr) # finalize locally
     yield() # flush gc msgs
-    if include_thread_unsafe_tests()
-        @test remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid) == true
-    end
+
+    @test timedwait(() -> remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid), 10) === :ok
+
     remotecall_fetch(r -> (finalize(take!(r)); yield(); nothing), wid2, fstore) # finalize remotely
     sleep(0.5) # to ensure that wid2 messages have been executed on wid1
     @test poll_while(() -> remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,14 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using Test
+
 # Run the distributed test outside of the main driver since it needs its own
 # set of dedicated workers.
 include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 disttestfile = joinpath(@__DIR__, "distributed_exec.jl")
 
-cmd = `$test_exename $test_exeflags $disttestfile`
-
-if !success(pipeline(cmd; stdout=stdout, stderr=stderr)) && ccall(:jl_running_on_valgrind,Cint,()) == 0
-    error("Distributed test failed, cmd : $cmd")
+@testset let cmd = `$test_exename $test_exeflags $disttestfile`
+    @test success(pipeline(cmd; stdout=stdout, stderr=stderr)) && ccall(:jl_running_on_valgrind,Cint,()) == 0
 end
 
 include("managers.jl")

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -1,5 +1,5 @@
 using Test
-using Distributed, Base.Threads
+using Distributed
 using Base.Iterators: product
 
 exeflags = ("--startup-file=no",
@@ -12,7 +12,7 @@ function call_on(f, wid, tid)
         t = Task(f)
         ccall(:jl_set_task_tid, Cvoid, (Any, Cint), t, tid - 1)
         schedule(t)
-        @assert threadid(t) == tid
+        @assert Threads.threadid(t) == tid
         t
     end
 end
@@ -27,12 +27,12 @@ isfailed(rr) = fetch_from_owner(istaskfailed, rr)
 
 @testset "RemoteChannel allows put!/take! from thread other than 1" begin
     ws = ts = product(1:2, 1:2)
+
+    # We want (the default) laziness, so that we wait for `Worker.c_state`!
+    procs_added = addprocs(2; exeflags, lazy=true)
+
     @testset "from worker $w1 to $w2 via 1" for (w1, w2) in ws
         @testset "from thread $w1.$t1 to $w2.$t2" for (t1, t2) in ts
-            # We want (the default) laziness, so that we wait for `Worker.c_state`!
-            procs_added = addprocs(2; exeflags, lazy=true)
-            @everywhere procs_added using Base.Threads
-
             p1 = procs_added[w1]
             p2 = procs_added[w2]
             chan_id = first(procs_added)
@@ -57,8 +57,8 @@ isfailed(rr) = fetch_from_owner(istaskfailed, rr)
 
             @test !isfailed(send)
             @test !isfailed(recv)
-
-            rmprocs(procs_added)
         end
     end
+
+    rmprocs(procs_added)
 end


### PR DESCRIPTION
Co-authored by @IanButterworth 

- 2c5eee0 upstreams a fix for hangs from DistributedNext
- 0928d68 includes some threadsafety changes from reviewing #101 on DistributedNext
- f7ba3ca enables multiple threads in CI to shake out problems
- [multiple commits] reverts `@spawn` to `@async` to get tests passing. Moving back to `@spawn` will take more work, but it should be low priority because the main thread, where Distributed usually runs, will already be `sticky` anyway, so the gain is minor.
- [`fbf8c12` (#122)](https://github.com/JuliaLang/Distributed.jl/pull/122/commits/fbf8c12bc44a92ba001a4898ad4ec48544cb9f00) is necessary to avoid each worker in those tests re-precompiling any stdlibs they use. Speeds up macos runs by ~1 minute
- [`97fc237` (#122)](https://github.com/JuliaLang/Distributed.jl/pull/122/commits/97fc23751a578c8bafb12eabbf8326f9b9610bfd) adds a sigusr1/siginfo profile before killing a worker that won't shut down, to aid debugging

Fixes https://github.com/JuliaLang/Distributed.jl/issues/124

## TODO
- [x] Fix https://github.com/JuliaLang/Distributed.jl/issues/124 (hacked around with `@async`)

CC @jpsamaroo 