### PR TITLE
Export `remotecall_eval`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,6 +21,7 @@ Distributed.fetch(::RemoteChannel)
 Distributed.remotecall(::Any, ::Integer, ::Any...)
 Distributed.remotecall_wait(::Any, ::Integer, ::Any...)
 Distributed.remotecall_fetch(::Any, ::Integer, ::Any...)
+Distributed.remotecall_eval
 Distributed.remote_do(::Any, ::Integer, ::Any...)
 Distributed.put!(::RemoteChannel, ::Any...)
 Distributed.put!(::Distributed.Future, ::Any)

--- a/src/Distributed.jl
+++ b/src/Distributed.jl
@@ -49,6 +49,7 @@ export
     procs,
     remote,
     remotecall,
+    remotecall_eval,
     remotecall_fetch,
     remotecall_wait,
     remote_do,


### PR DESCRIPTION
`@everywhere` has (slightly surprising) behaviour for `using`/`import` statements that can best be avoided by using `remotecall_eval` directly, so i think `remotecall_eval` should be exported (or at least marked `public` but i think `export` is fine here.

Context:

The behaviour of `@everywhere` is that it tries to find `using`/`import` statements and run them on the calling process first, which means an `@everywhere` can't be defined inside a function if it contains a `using`/`import` (unless you add a hack to cause `@everywhere` to not find your `using`/`import`).

i.e. while this works
```julia
julia> module Foo end
Main.Foo

julia> @everywhere workers() begin
           using .Foo
       end
```
This fails:
```julia
julia> function f()
           @everywhere workers() begin
               using .Foo
           end
       end
ERROR: syntax: "toplevel" expression not at top level
```
An ugly hack to "hide" the `using` in  a function call (lol this works):
```julia
julia> function f()
           @everywhere workers() begin
               print(using .Foo)
           end
       end
f (generic function with 1 method)

julia> f()
```
But a better solution is to just not use `@everywhere`, since this is it's documented behaviour:
```
  Similar to calling remotecall_eval(Main, procs, expr), but with two extra features:

    •  using and import statements run on the calling process first, to ensure packages are precompiled.

    •  The current source file path used by include is propagated to other processes.
```
and instead use `remotecall_eval` just as the docstring for `@everywhere` mentions, i.e.
```julia
remotecall_eval(Main, workers(), :(using .Foo))
```