### PR TITLE
Fix ambiguity in remotecall_pool specialized for remotecall. Add test. Add Aqua tests.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,19 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[compat]
+Aqua = "0.8.10"
+LinearAlgebra = "1"
+Random = "1"
+Serialization = "1"
+Sockets = "1"
+Test = "1"
+julia = "1"
+
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "Test"]
+test = ["Aqua", "LinearAlgebra", "Test"]

--- a/src/workerpool.jl
+++ b/src/workerpool.jl
@@ -149,6 +149,7 @@ function remotecall_pool(rc_f::typeof(remotecall), f, pool::AbstractWorkerPool, 
 
     t = Threads.@spawn Threads.threadpool() try
         wait(x)
+    catch # just wait, ignore errors here
     finally
         put!(pool, worker)
     end
@@ -418,6 +419,7 @@ function remotecall_pool(rc_f::typeof(remotecall), f, pool::CachingPool, args...
 
     t = Threads.@spawn Threads.threadpool() try
         wait(x)
+    catch # just wait, ignore errors here
     finally
         put!(pool, worker)
     end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,9 @@
+using Aqua
+using Distributed
+
+Aqua.test_all(
+    Distributed,
+    # This should be excluded, but it's not clear how to do that on Aqua's API
+    # given it's not-defined. (The Julia Base ambiguity test does it something like this)
+    # ambiguities=(exclude=[GlobalRef(Distributed, :cluster_manager)])
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test
+using Distributed
+
+if !Base.get_bool_env("BUILDKITE", false)
+    @testset "Aqua.jl tests" begin
+        include("aqua.jl")
+    end
+end
 
 # Run the distributed test outside of the main driver since it needs its own
 # set of dedicated workers.


### PR DESCRIPTION
Fixes failure on julia CI https://github.com/JuliaLang/julia/pull/57162 
also adds the same ambiguity test here.

```
  | 2025-01-26 11:12:11 EST | ambiguous                                        (3) \|         failed at 2025-01-26T08:12:11.695
  | 2025-01-26 11:12:11 EST | Test Failed at /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-94bacb2dc4/share/julia/test/ambiguous.jl:205
  | 2025-01-26 11:12:11 EST | Expression: isempty(detect_ambiguities(modules...; recursive = true, allowed_undefineds))
  | 2025-01-26 11:12:11 EST | Evaluated: isempty(Tuple{Method, Method}[(remotecall_pool(rc_f::typeof(remotecall), f, pool::AbstractWorkerPool, args...; kwargs...) @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-94bacb2dc4/share/julia/stdlib/v1.12/Distributed/src/workerpool.jl:140, remotecall_pool(rc_f, f, pool::CachingPool, args...; kwargs...) @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-94bacb2dc4/share/julia/stdlib/v1.12/Distributed/src/workerpool.jl:392), (kwcall(::NamedTuple, ::typeof(Distributed.remotecall_pool), rc_f::typeof(remotecall), f, pool::AbstractWorkerPool, args...) @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-94bacb2dc4/share/julia/stdlib/v1.12/Distributed/src/workerpool.jl:140, kwcall(::NamedTuple, ::typeof(Distributed.remotecall_pool), rc_f, f, pool::CachingPool, args...) @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-94bacb2dc4/share/julia/stdlib/v1.12/Distributed/src/workerpool.jl:392)])
  | 2025-01-26 11:12:11 EST
```