### PR TITLE
`SSHManager`: Add the `custom_worker_flag` option, but don't add it to the public API

### DIFF
--- a/src/managers.jl
+++ b/src/managers.jl
@@ -168,6 +168,7 @@ default_addprocs_params(::SSHManager) =
               :sshflags       => ``,
               :shell          => :posix,
               :cmdline_cookie => false,
+              :custom_worker_flag => nothing,
               :env            => [],
               :tunnel         => false,
               :multiplex      => false,
@@ -238,6 +239,7 @@ function launch_on_machine(manager::SSHManager, machine::AbstractString, cnt, pa
     tunnel = params[:tunnel]
     multiplex = params[:multiplex]
     cmdline_cookie = params[:cmdline_cookie]
+    custom_worker_flag = params[:custom_worker_flag]
     env = Dict{String,String}(params[:env])
 
     # machine could be of the format [user@]host[:port] bind_addr[:bind_port]
@@ -249,10 +251,14 @@ function launch_on_machine(manager::SSHManager, machine::AbstractString, cnt, pa
     if length(machine_bind) > 1
         exeflags = `--bind-to $(machine_bind[2]) $exeflags`
     end
-    if cmdline_cookie
-        exeflags = `$exeflags --worker=$(cluster_cookie())`
+    if isnothing(custom_worker_flag)
+        if cmdline_cookie
+            exeflags = `$exeflags --worker=$(cluster_cookie())`
+        else
+            exeflags = `$exeflags --worker`
+        end
     else
-        exeflags = `$exeflags --worker`
+        exeflags = `$exeflags $custom_worker_flag`
     end
 
     host, portnum = parse_machine(machine_bind[1])


### PR DESCRIPTION
## Description

I have a use case where, instead of starting each remote worker with `julia --worker`, I need to start the remote workers with `julia -e 'my_custom_code()'`.

This PR modifies `SSHManager` to have a `custom_worker_flag` option. When `custom_worker_flag` is specified, it will replace `--worker`. When `custom_worker_flag` is not specified (which is the default), it falls back to the current behavior.

## Example usage

```julia
using Distributed: addprocs

hosts = ["host1", "host2", "host3"]

julia_code = """
    my_custom_code()
"""

addprocs(hosts; custom_worker_flag = `-e "$(julia_code)"`) 
```

This will start each remote worker with `julia -e 'my_custom_code()'`.

## Public API vs private API

This PR does not add the new `custom_worker_flag` option to the public API. This allows us to change (or remove) it in the future.