### PR TITLE
Display codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Distributed
 
+[![codecov](https://codecov.io/gh/JuliaLang/Distributed.jl/graph/badge.svg?token=TzEHMuk1E3)](https://codecov.io/gh/JuliaLang/Distributed.jl)
+
 The `Distributed` package provides functionality for creating and controlling
 multiple Julia processes remotely, and for performing distributed and parallel
 computing. It uses network sockets or other supported interfaces to communicate


### PR DESCRIPTION
The current test coverage sits at around 79%, which I consider low for a language standard library.

I think it would be helpful to display the Codecov badge in the README as a gentle motivator to improve coverage :-)
