### PR TITLE
Display backtrace from unexpected errors in `terminate_all_workers()`

### DIFF
--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -1275,7 +1275,12 @@ function terminate_all_workers()
         try
             rmprocs(workers(); waitfor=5.0)
         catch _ex
-            @warn "Forcibly interrupting busy workers" exception=_ex
+            if _ex isa ErrorException
+                @warn "Forcibly interrupting busy workers" exception=_ex
+            else
+                @error "Unexpected error when interrupting busy workers" exception=(_ex, catch_backtrace())
+            end
+
             # Might be computation bound, interrupt them and try again
             interrupt(workers())
             try


### PR DESCRIPTION
I'm hoping this will help debug failures like these: https://buildkite.com/julialang/julia-master/builds/56445/steps/canvas?sid=019d7e70-1b2a-4462-8d03-2a44509e7792#019d7e70-1b59-4033-960c-cf31781e32f6/L2025