### PR TITLE
process_messages: don't let a failed error report skip worker teardown

### DIFF
--- a/src/managers.jl
+++ b/src/managers.jl
@@ -474,12 +474,10 @@ end
 
 Base.show(io::IO, manager::LocalManager) = print(io, "LocalManager()")
 
-function launch(manager::LocalManager, params::Dict, launched::Array, c::Condition)
-    dir = params[:dir]
-    exename = params[:exename]
-    exeflags = params[:exeflags]
-    bind_to = manager.restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
-    env = Dict{String,String}(params[:env])
+# The environment a worker launched on this host needs in order to run the same code as this
+# process.
+function local_worker_env(env=Dict{String,String}(); enable_threaded_blas::Bool=false)
+    env = Dict{String,String}(env)
 
     # TODO: Maybe this belongs in base/initdefs.jl as a package_environment() function
     #       together with load_path() etc. Might be useful to have when spawning julia
@@ -497,7 +495,7 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
 
     # If we haven't explicitly asked for threaded BLAS, prevent OpenBLAS from starting
     # up with multiple threads, thereby sucking up a bunch of wasted memory on Windows.
-    if !params[:enable_threaded_blas] &&
+    if !enable_threaded_blas &&
        get(env, "OPENBLAS_NUM_THREADS", nothing) === nothing
         env["OPENBLAS_NUM_THREADS"] = "1"
     end
@@ -509,10 +507,39 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
         env["JULIA_PROJECT"] = project
     end
 
+    return env
+end
+
+# A command for another julia process on this host, configured the way `addprocs` configures a
+# worker's, so that it runs the same code as this process.
+function local_julia_cmd(; exename=joinpath(Sys.BINDIR, julia_exename()), exeflags=``,
+                         dir=pwd(), env::Dict{String,String}=local_worker_env())
+    return setenv(addenv(`$(julia_cmd(exename)) $exeflags`, env), dir=dir)
+end
+
+# `local_julia_cmd` for a worker. Detached, since a worker must not share its master's process
+# group.
+function local_worker_cmd(; restrict::Bool=true, exeflags=``, kwargs...)
+    bind_to = restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
+    return detach(local_julia_cmd(; exeflags=`$exeflags --bind-to $bind_to --worker`, kwargs...))
+end
+
+# Start one `local_worker_cmd`, cookie already written to it, leaving the caller to drive the
+# connection setup protocol (see `create_worker`). We hold its stdin and stdout, and
+# `start_worker` redirects its stderr onto that stdout, so we are the only reader of everything
+# it reports.
+function launch_local_worker(; kwargs...)
+    io = open(local_worker_cmd(; kwargs...), "r+")
+    write_cookie(io)
+    return io
+end
+
+function launch(manager::LocalManager, params::Dict, launched::Array, c::Condition)
+    env = local_worker_env(params[:env]; enable_threaded_blas=params[:enable_threaded_blas])
+
     for i in 1:manager.np
-        cmd = `$(julia_cmd(exename)) $exeflags --bind-to $bind_to --worker`
-        io = open(detach(setenv(addenv(cmd, env), dir=dir)), "r+")
-        write_cookie(io)
+        io = launch_local_worker(; exename=params[:exename], exeflags=params[:exeflags],
+                                 dir=params[:dir], restrict=manager.restrict, env)
 
         wconfig = WorkerConfig()
         wconfig.process = io

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -168,6 +168,28 @@ function deserialize_hdr_raw(io)
     return MsgHeader(RRID(data[1], data[2]), RRID(data[3], data[4]))
 end
 
+# Write one message in the wire format described at the top of this file. Takes a plain stream
+# rather than a `Worker`, since the connection setup protocol (see `create_worker`) runs before
+# either end has a `Worker` for the other. Locking and flushing `io` is the caller's job.
+function write_msg(io::IO, serializer::AbstractSerializer, header, msg)
+    reset_state(serializer)
+    serialize_hdr_raw(io, header)
+    invokelatest(serialize_msg, serializer, msg)  # io is wrapped in serializer
+    write(io, MSG_BOUNDARY)
+    return nothing
+end
+
+# The inverse, for readers that can let a deserialization error propagate. `message_handler_loop`
+# reads its messages inline instead, so that it can recover from one by resynchronizing on the
+# boundary.
+function read_msg(io::IO, serializer::AbstractSerializer, boundary::Vector{UInt8}=similar(MSG_BOUNDARY))
+    reset_state(serializer)
+    header = deserialize_hdr_raw(io)
+    msg = deserialize_msg(serializer)
+    readbytes!(io, boundary, length(MSG_BOUNDARY))
+    return header, msg
+end
+
 function send_msg_(w::Worker, header, msg, now::Bool)
     check_worker_state(w)
     if myid() != 1 && !isa(msg, IdentifySocketMsg) && !isa(msg, IdentifySocketAckMsg)
@@ -176,11 +198,7 @@ function send_msg_(w::Worker, header, msg, now::Bool)
     io = w.w_stream
     lock(io)
     try
-        reset_state(w.w_serializer)
-        serialize_hdr_raw(io, header)
-        invokelatest(serialize_msg, w.w_serializer, msg)  # io is wrapped in w_serializer
-        write(io, MSG_BOUNDARY)
-
+        write_msg(io, w.w_serializer, header, msg)
         if !now && w.gcflag
             flush_gc_msgs(w)
         else
@@ -204,12 +222,13 @@ function flush_gc_msgs()
     end
 end
 
-function send_connection_hdr(w::Worker, cookie=true)
+function send_connection_hdr(io::IO, cookie=true)
     # For a connection initiated from the remote side to us, we only send the version,
     # else when we initiate a connection we first send the cookie followed by our version.
     # The remote side validates the cookie.
     if cookie
-        write(w.w_stream, LPROC.cookie)
+        write(io, LPROC.cookie)
     end
-    write(w.w_stream, rpad(VERSION_STRING, HDR_VERSION_LEN)[1:HDR_VERSION_LEN])
+    write(io, rpad(VERSION_STRING, HDR_VERSION_LEN)[1:HDR_VERSION_LEN])
 end
+send_connection_hdr(w::Worker, cookie=true) = send_connection_hdr(w.w_stream, cookie)

--- a/src/process_messages.jl
+++ b/src/process_messages.jl
@@ -103,7 +103,12 @@ function deliver_result(sock::IO, msg, oid, value)
     catch e
         # terminate connection in case of serialization error
         # otherwise the reading end would hang
-        @error "Fatal error on process $(myid())" exception=e,catch_backtrace()
+        # a worker's stderr is a pipe to its master (see `start_worker`), so reporting can
+        # itself throw EPIPE; the teardown below has to run either way
+        try
+            @error "Fatal error on process $(myid())" exception=e,catch_backtrace()
+        catch
+        end
         wid = worker_id_from_socket(sock)
         close(sock)
         if myid()==1
@@ -159,13 +164,21 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
         serializer = ClusterSerializer(r_stream)
 
         # The first message will associate wpid with r_stream
-        header = deserialize_hdr_raw(r_stream)
-        msg = deserialize_msg(serializer)
+        header, msg = read_msg(r_stream, serializer, boundary)
         handle_msg(msg, header, r_stream, w_stream, version)
         wpid = worker_id_from_socket(r_stream)
         @assert wpid > 0
 
-        readbytes!(r_stream, boundary, length(MSG_BOUNDARY))
+        if wpid == 1 && myid() != 1
+            # this worker should not outlive its connection to master
+            exiter = @task exit(1)
+            exiter.sticky = false
+            if isdefined(Base, :schedule_on_notify!)
+                Base.schedule_on_notify!(current_task(), exiter)
+            else
+                Base._wait2(current_task(), exiter)
+            end
+        end
 
         while true
             reset_state(serializer)
@@ -218,14 +231,19 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
         end
 
         if wpid < 1
-            println(stderr, e, CapturedException(e, catch_backtrace()))
-            println(stderr, "Process($(myid())) - Unknown remote, closing connection.")
+            # reporting may throw (see `deliver_result`); the cleanup below still runs
+            try
+                println(stderr, e, CapturedException(e, catch_backtrace()))
+                println(stderr, "Process($(myid())) - Unknown remote, closing connection.")
+            catch
+            end
         elseif !(wpid in map_del_wrkr)
             werr = worker_from_id(wpid)
             oldstate = @atomic werr.state
             set_worker_state(werr, W_TERMINATED)
 
             # If unhandleable error occurred talking to pid 1, exit
+            # the exit armed above covers this too, should the report below throw
             if wpid == 1
                 if isopen(w_stream)
                     @error "Fatal error on process $(myid())" exception=e,catch_backtrace()
@@ -372,7 +390,11 @@ function connect_to_peer(manager::ClusterManager, rpid::Int, wconfig::WorkerConf
         send_msg_now(w, MsgHeader(), IdentifySocketMsg(myid()))
         notify(w.initialized)
     catch e
-        @error "Error on $(myid()) while connecting to peer $rpid, exiting" exception=e,catch_backtrace()
+        # reporting may throw (see `deliver_result`); the exit below still runs
+        try
+            @error "Error on $(myid()) while connecting to peer $rpid, exiting" exception=e,catch_backtrace()
+        catch
+        end
         exit(1)
     end
 end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1286,17 +1286,17 @@ function launch(manager::ErrorSimulator, params::Dict, launched::Array, c::Condi
     exename = params[:exename]
     dir = params[:dir]
 
-    cmd = `$(Base.julia_cmd(exename)) --startup-file=no`
     if manager.mode === :timeout
-        cmd = `$cmd -e "sleep(10)"`
+        exeflags = `--startup-file=no -e "sleep(10)"`
     elseif manager.mode === :ntries
-        cmd = `$cmd -e "[println(x) for x in 1:1001]"`
+        exeflags = `--startup-file=no -e "[println(x) for x in 1:1001]"`
     elseif manager.mode === :exit
-        cmd = `$cmd -e "exit(-1)"`
+        exeflags = `--startup-file=no -e "exit(-1)"`
     else
         error("Unknown mode")
     end
-    io = open(detach(setenv(cmd, dir=dir)))
+    # everything a local worker is launched with except for `--worker` itself
+    io = open(detach(Distributed.local_julia_cmd(; exename, exeflags, dir)))
 
     wconfig = WorkerConfig()
     wconfig.process = io
@@ -1996,6 +1996,40 @@ begin
             redirect_stderr(devnull)
         end
         wait(rmprocs([w]))
+    end
+end
+
+# Test that a worker doesn't outlive its connection to master. The misbehaving master is simulated here.
+let io = Distributed.launch_local_worker(; exename=test_exename)
+    try
+        host, port = Distributed.read_worker_host_port(io.out)
+        sock = connect(host, port)
+
+        # act like pid 1 on the wire, without registering a `Worker` for it here; nothing
+        # local refers to the pid we hand it
+        Distributed.send_connection_hdr(sock, true)
+        hdr = Distributed.MsgHeader(Distributed.RRID(0, 0), Distributed.RRID(0, 0))
+        join_message = Distributed.JoinPGRPMsg(maximum(procs()) + 1, [], :all_to_all, false, false)
+        Distributed.write_msg(sock, Distributed.ClusterSerializer(sock), hdr, join_message)
+        flush(sock)
+
+        # the worker is primed once it answers
+        @test Distributed.process_hdr(sock, false) isa VersionNumber
+        _, msg = Distributed.read_msg(sock, Distributed.ClusterSerializer(sock))
+        @test msg isa Distributed.JoinCompleteMsg
+        @test process_running(io)
+
+        close(io)     # nothing reads its stderr pipe now, so reporting throws EPIPE
+        close(sock)   # and pid 1 is gone, so its message loop sees an EOFError
+
+        watchdog = Timer(_ -> kill(io, Base.SIGKILL), 60)   # never hang the suite on this
+        wait(io)
+        close(watchdog)
+        @test io.exitcode == 1
+    finally
+        # don't leak the worker if anything above threw
+        process_running(io) && kill(io, Base.SIGKILL)
+        close(io)
     end
 end
 


### PR DESCRIPTION
A worker should not outlive its master, but the `exit(1)` enforcing that sat behind error reporting which fails in exactly the circumstance the exit exists for. `start_worker` redirects a worker's stderr to its stdout, a pipe held only by the master, so when the master dies the worker's `EOFError` handling writes to a reader-less pipe and raises `EPIPE`. `@error` does not contain that: when `catch_exceptions(logger)` is false it rethrows, and when true the recovery report in
`Base.CoreLogging.logging_error` writes to the same broken stream unguarded. The throw escaped `message_handler_loop`'s `catch`, skipping both `exit(1)` and the stream closes, and the worker then idled in `start_worker`'s wait loop indefinitely, holding its socket in `CLOSE-WAIT`.

Arm the exit on completion of the task servicing the connection to pid 1 so it no longer depends on anything in the error path succeeding, and guard the remaining raw `stderr` writes that gate cleanup in `deliver_result`, `connect_to_peer`, and the unidentified-peer branch of `message_handler_loop`.